### PR TITLE
Map 3 well known extensions to google docs mime types

### DIFF
--- a/mime.types.custom
+++ b/mime.types.custom
@@ -19,5 +19,5 @@ image/x-ms-bmp					bmp
 text/php					php
 text/x-php					php
 application/vnd.google-apps.document          docx
-application/vnd.google-apps.spreadsheet         xlsx
-application/vnd.google-apps.presentation          pptx
+application/vnd.google-apps.spreadsheet       xlsx
+application/vnd.google-apps.presentation      pptx


### PR DESCRIPTION
Some of the mime types defined here https://developers.google.com/drive/api/v3/mime-types should be added. It is useful when using google drive extensions, as google docs do not require an extension and the only way to find an extension is mime type conversion.