### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 
 before_script:
   - composer install

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,17 @@
     "php": "^5.4|^7.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~3.7.0",
-    "satooshi/php-coveralls": ">=1.0"
+    "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5",
+    "php-coveralls/php-coveralls": "^1.1"
   },
   "autoload": {
     "psr-4": {
       "Mimey\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Mimey\\Tests\\": "tests/src/"
     }
   }
 }

--- a/mime.types.php
+++ b/mime.types.php
@@ -5,6 +5,15 @@
     array (
       0 => 'application/font-woff',
     ),
+    'php' => 
+    array (
+      0 => 'application/php',
+      1 => 'application/x-httpd-php',
+      2 => 'application/x-httpd-php-source',
+      3 => 'application/x-php',
+      4 => 'text/php',
+      5 => 'text/x-php',
+    ),
     'otf' => 
     array (
       0 => 'application/x-font-otf',
@@ -69,10 +78,6 @@
     array (
       0 => 'image/x-ms-bmp',
       1 => 'image/bmp',
-    ),
-    'php' => 
-    array (
-      0 => 'text/x-php',
     ),
     'ez' => 
     array (
@@ -3959,6 +3964,10 @@
     array (
       0 => 'wof',
     ),
+    'application/php' => 
+    array (
+      0 => 'php',
+    ),
     'application/x-font-otf' => 
     array (
       0 => 'otf',
@@ -3971,6 +3980,18 @@
     'application/x-gzip' => 
     array (
       0 => 'zip',
+    ),
+    'application/x-httpd-php' => 
+    array (
+      0 => 'php',
+    ),
+    'application/x-httpd-php-source' => 
+    array (
+      0 => 'php',
+    ),
+    'application/x-php' => 
+    array (
+      0 => 'php',
     ),
     'audio/amr' => 
     array (
@@ -3994,6 +4015,10 @@
     'image/x-ms-bmp' => 
     array (
       0 => 'bmp',
+    ),
+    'text/php' => 
+    array (
+      0 => 'php',
     ),
     'text/x-php' => 
     array (

--- a/tests/src/MimeMappingBuilderTest.php
+++ b/tests/src/MimeMappingBuilderTest.php
@@ -1,70 +1,71 @@
 <?php
 
-class MimeMappingBuilderTest extends \PHPUnit_Framework_TestCase
+namespace Mimey\Tests;
+
+use Mimey\MimeTypes;
+use Mimey\MimeMappingBuilder;
+use PHPUnit\Framework\TestCase;
+
+class MimeMappingBuilderTest extends TestCase
 {
-	protected function setUp()
-	{
-
-	}
-
 	public function testFromEmpty()
 	{
-		$builder = \Mimey\MimeMappingBuilder::blank();
+		$builder = MimeMappingBuilder::blank();
 		$builder->add('foo/bar', 'foobar');
 		$builder->add('foo/bar', 'bar');
 		$builder->add('foo/baz', 'foobaz');
-		$mime = new \Mimey\MimeTypes($builder->getMapping());
+		$mime = new MimeTypes($builder->getMapping());
 		$this->assertEquals('bar', $mime->getExtension('foo/bar'));
-		$this->assertEquals(array('bar', 'foobar'), $mime->getAllExtensions('foo/bar'));
+		$this->assertEquals(['bar', 'foobar'], $mime->getAllExtensions('foo/bar'));
 		$this->assertEquals('foobaz', $mime->getExtension('foo/baz'));
-		$this->assertEquals(array('foobaz'), $mime->getAllExtensions('foo/baz'));
+		$this->assertEquals(['foobaz'], $mime->getAllExtensions('foo/baz'));
 		$this->assertEquals('foo/bar', $mime->getMimeType('foobar'));
-		$this->assertEquals(array('foo/bar'), $mime->getAllMimeTypes('foobar'));
+		$this->assertEquals(['foo/bar'], $mime->getAllMimeTypes('foobar'));
 		$this->assertEquals('foo/bar', $mime->getMimeType('bar'));
-		$this->assertEquals(array('foo/bar'), $mime->getAllMimeTypes('bar'));
+		$this->assertEquals(['foo/bar'], $mime->getAllMimeTypes('bar'));
 		$this->assertEquals('foo/baz', $mime->getMimeType('foobaz'));
-		$this->assertEquals(array('foo/baz'), $mime->getAllMimeTypes('foobaz'));
+		$this->assertEquals(['foo/baz'], $mime->getAllMimeTypes('foobaz'));
 	}
 
 	public function testFromBuiltIn()
 	{
-		$builder = \Mimey\MimeMappingBuilder::create();
-		$mime1 = new \Mimey\MimeTypes($builder->getMapping());
+		$builder = MimeMappingBuilder::create();
+		$mime1 = new MimeTypes($builder->getMapping());
 		$this->assertEquals('json', $mime1->getExtension('application/json'));
 		$this->assertEquals('application/json', $mime1->getMimeType('json'));
 
 		$builder->add('application/json', 'mycustomjson');
-		$mime2 = new \Mimey\MimeTypes($builder->getMapping());
+		$mime2 = new MimeTypes($builder->getMapping());
 		$this->assertEquals('mycustomjson', $mime2->getExtension('application/json'));
 		$this->assertEquals('application/json', $mime2->getMimeType('json'));
 
 		$builder->add('application/mycustomjson', 'json');
-		$mime3 = new \Mimey\MimeTypes($builder->getMapping());
+		$mime3 = new MimeTypes($builder->getMapping());
 		$this->assertEquals('mycustomjson', $mime3->getExtension('application/json'));
 		$this->assertEquals('application/mycustomjson', $mime3->getMimeType('json'));
 	}
 
 	public function testAppendExtension()
 	{
-		$builder = \Mimey\MimeMappingBuilder::blank();
+		$builder = MimeMappingBuilder::blank();
 		$builder->add('foo/bar', 'foobar');
 		$builder->add('foo/bar', 'bar', false);
-		$mime = new \Mimey\MimeTypes($builder->getMapping());
+		$mime = new MimeTypes($builder->getMapping());
 		$this->assertEquals('foobar', $mime->getExtension('foo/bar'));
 	}
 
 	public function testAppendMime()
 	{
-		$builder = \Mimey\MimeMappingBuilder::blank();
+		$builder = MimeMappingBuilder::blank();
 		$builder->add('foo/bar', 'foobar');
 		$builder->add('foo/bar2', 'foobar', true, false);
-		$mime = new \Mimey\MimeTypes($builder->getMapping());
+		$mime = new MimeTypes($builder->getMapping());
 		$this->assertEquals('foo/bar', $mime->getMimeType('foobar'));
 	}
 
 	public function testSave()
 	{
-		$builder = \Mimey\MimeMappingBuilder::blank();
+		$builder = MimeMappingBuilder::blank();
 		$builder->add('foo/one', 'one');
 		$builder->add('foo/one', 'one1');
 		$builder->add('foo/two', 'two');
@@ -73,7 +74,7 @@ class MimeMappingBuilderTest extends \PHPUnit_Framework_TestCase
 		$builder->save($file);
 		$mapping_included = require $file;
 		$this->assertEquals($builder->getMapping(), $mapping_included);
-		$builder2 = \Mimey\MimeMappingBuilder::load($file);
+		$builder2 = MimeMappingBuilder::load($file);
 		unlink($file);
 		$this->assertEquals($builder->getMapping(), $builder2->getMapping());
 	}

--- a/tests/src/MimeMappingGeneratorTest.php
+++ b/tests/src/MimeMappingGeneratorTest.php
@@ -1,10 +1,15 @@
 <?php
 
-class MimeMappingGeneratorTest extends \PHPUnit_Framework_TestCase
+namespace Mimey\Tests;
+
+use Mimey\MimeMappingGenerator;
+use PHPUnit\Framework\TestCase;
+
+class MimeMappingGeneratorTest extends TestCase
 {
 	public function testGenerateMapping()
 	{
-		$generator = new \Mimey\MimeMappingGenerator(
+		$generator = new MimeMappingGenerator(
 			"#ignore\tme\n" .
 			"application/json\t\t\tjson\n" .
 			"image/jpeg\t\t\tjpeg jpg #ignore this too\n\n" .
@@ -12,21 +17,21 @@ class MimeMappingGeneratorTest extends \PHPUnit_Framework_TestCase
 			"qux\tbar\n"
 		);
 		$mapping = $generator->generateMapping();
-		$expected = array(
-			'mimes' => array(
-				'json' => array('application/json'),
-				'jpeg' => array('image/jpeg'),
-				'jpg' => array('image/jpeg'),
-				'bar' => array('foo', 'qux'),
-				'baz' => array('foo')
-			),
-			'extensions' => array(
-				'application/json' => array('json'),
-				'image/jpeg' => array('jpeg', 'jpg'),
-				'foo' => array('bar', 'baz'),
-				'qux' => array('bar')
-			)
-		);
+		$expected = [
+			'mimes' => [
+				'json' => ['application/json'],
+				'jpeg' => ['image/jpeg'],
+				'jpg' => ['image/jpeg'],
+				'bar' => ['foo', 'qux'],
+				'baz' => ['foo'],
+			],
+			'extensions' => [
+				'application/json' => ['json'],
+				'image/jpeg' => ['jpeg', 'jpg'],
+				'foo' => ['bar', 'baz'],
+				'qux' => ['bar'],
+			],
+		];
 		$this->assertEquals($expected, $mapping);
 
 		$code = $generator->generateMappingCode();

--- a/tests/src/MimeTypesTest.php
+++ b/tests/src/MimeTypesTest.php
@@ -1,86 +1,149 @@
 <?php
 
-class MimeTypesTest extends \PHPUnit_Framework_TestCase
+namespace Mimey\Tests;
+
+use Mimey\MimeTypes;
+use PHPUnit\Framework\TestCase;
+
+class MimeTypesTest extends TestCase
 {
 	/** @var \Mimey\MimeTypes */
 	protected $mime;
 
 	protected function setUp()
 	{
-		$this->mime = new \Mimey\MimeTypes(array(
-			'mimes' => array(
-				'json' => array('application/json'),
-				'jpeg' => array('image/jpeg'),
-				'jpg' => array('image/jpeg'),
-				'bar' => array('foo', 'qux'),
-				'baz' => array('foo')
-			),
-			'extensions' => array(
-				'application/json' => array('json'),
-				'image/jpeg' => array('jpeg', 'jpg'),
-				'foo' => array('bar', 'baz'),
-				'qux' => array('bar')
-			)
-		));
+		$this->mime = new MimeTypes([
+			'mimes' => [
+				'json' => ['application/json'],
+				'jpeg' => ['image/jpeg'],
+				'jpg' => ['image/jpeg'],
+				'bar' => ['foo', 'qux'],
+				'baz' => ['foo'],
+			],
+			'extensions' => [
+				'application/json' => ['json'],
+				'image/jpeg' => ['jpeg', 'jpg'],
+				'foo' => ['bar', 'baz'],
+				'qux' => ['bar'],
+			],
+		]);
 	}
 
-	public function testGetMimeType()
+	public function getMimeTypeProvider()
 	{
-		$this->assertEquals('application/json', $this->mime->getMimeType('json'));
-		$this->assertEquals('image/jpeg', $this->mime->getMimeType('jpeg'));
-		$this->assertEquals('image/jpeg', $this->mime->getMimeType('jpg'));
-		$this->assertEquals('foo', $this->mime->getMimeType('bar'));
-		$this->assertEquals('foo', $this->mime->getMimeType('baz'));
+		return [
+			['application/json', 'json'],
+			['image/jpeg', 'jpeg'],
+			['image/jpeg', 'jpg'],
+			['foo', 'bar'],
+			['foo', 'baz'],
+		];
 	}
 
-	public function testGetExtension()
+	/**
+	 * @dataProvider getMimeTypeProvider
+	 */
+	public function testGetMimeType($expectedMimeType, $extension)
 	{
-		$this->assertEquals('json', $this->mime->getExtension('application/json'));
-		$this->assertEquals('jpeg', $this->mime->getExtension('image/jpeg'));
-		$this->assertEquals('bar', $this->mime->getExtension('foo'));
-		$this->assertEquals('bar', $this->mime->getExtension('qux'));
+		$this->assertEquals($expectedMimeType, $this->mime->getMimeType($extension));
 	}
 
-	public function testGetAllMimeTypes()
+	public function getExtensionProvider()
 	{
-		$this->assertEquals(array('application/json'), $this->mime->getAllMimeTypes('json'));
-		$this->assertEquals(array('image/jpeg'), $this->mime->getAllMimeTypes('jpeg'));
-		$this->assertEquals(array('image/jpeg'), $this->mime->getAllMimeTypes('jpg'));
-		$this->assertEquals(array('foo', 'qux'), $this->mime->getAllMimeTypes('bar'));
-		$this->assertEquals(array('foo'), $this->mime->getAllMimeTypes('baz'));
+		return [
+			['json', 'application/json'],
+			['jpeg', 'image/jpeg'],
+			['bar', 'foo'],
+			['bar', 'qux'],
+		];
 	}
 
-	public function testGetAllExtensions()
+	/**
+	 * @dataProvider getExtensionProvider
+	 */
+	public function testGetExtension($expectedExtension, $mimeType)
 	{
-		$this->assertEquals(array('json'), $this->mime->getAllExtensions('application/json'));
-		$this->assertEquals(array('jpeg', 'jpg'), $this->mime->getAllExtensions('image/jpeg'));
-		$this->assertEquals(array('bar', 'baz'), $this->mime->getAllExtensions('foo'));
-		$this->assertEquals(array('bar'), $this->mime->getAllExtensions('qux'));
+		$this->assertEquals($expectedExtension, $this->mime->getExtension($mimeType));
+	}
+
+	public function getAllMimeTypesProvider()
+	{
+		return [
+			[
+				['application/json'], 'json',
+			],
+			[
+				['image/jpeg'], 'jpeg',
+			],
+			[
+				['image/jpeg'], 'jpg',
+			],
+			[
+				['foo', 'qux'], 'bar',
+			],
+			[
+				['foo'], 'baz',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider getAllMimeTypesProvider
+	 */
+	public function testGetAllMimeTypes($expectedMimeTypes, $extension)
+	{
+		$this->assertEquals($expectedMimeTypes, $this->mime->getAllMimeTypes($extension));
+	}
+
+	public function getAllExtensionsProvider()
+	{
+		return [
+			[
+				['json'], 'application/json',
+			],
+			[
+				['jpeg', 'jpg'], 'image/jpeg',
+			],
+			[
+				['bar', 'baz'], 'foo',
+			],
+			[
+				['bar'], 'qux',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider getAllExtensionsProvider
+	 */
+	public function testGetAllExtensions($expectedExtensions, $mimeType)
+	{
+		$this->assertEquals($expectedExtensions, $this->mime->getAllExtensions($mimeType));
 	}
 
 	public function testGetMimeTypeUndefined()
 	{
-		$this->assertEquals(null, $this->mime->getMimeType('undefined'));
+		$this->assertNull($this->mime->getMimeType('undefined'));
 	}
 
 	public function testGetExtensionUndefined()
 	{
-		$this->assertEquals(null, $this->mime->getExtension('undefined'));
+		$this->assertNull($this->mime->getExtension('undefined'));
 	}
 
 	public function testGetAllMimeTypesUndefined()
 	{
-		$this->assertEquals(array(), $this->mime->getAllMimeTypes('undefined'));
+		$this->assertEquals([], $this->mime->getAllMimeTypes('undefined'));
 	}
 
 	public function testGetAllExtensionsUndefined()
 	{
-		$this->assertEquals(array(), $this->mime->getAllExtensions('undefined'));
+		$this->assertEquals([], $this->mime->getAllExtensions('undefined'));
 	}
 
 	public function testBuiltInMapping()
 	{
-		$mime = new \Mimey\MimeTypes();
+		$mime = new MimeTypes();
 		$this->assertEquals('json', $mime->getExtension('application/json'));
 		$this->assertEquals('application/json', $mime->getMimeType('json'));
 	}


### PR DESCRIPTION
# Changed log
- When `php-5.3` support is dropped, using the shorten array syntax because it's the `php-5.4+` feature.
- Using the `assertNull` method to assert the result value is null.
- Using the `dataProvider` to collect test cases and split test cases from the test method block.
- Define the multiple PHPUnit versions to support different PHP versions.
- Add `php-7.2` and `php-7.3` tests in Travis CI build.
- The `satooshi/php-coveralls` is abandoned and using the `php-coveralls/php-coveralls` instead.